### PR TITLE
Add SPI to ArduinoFake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 **/Makefile
 !/Makefile
 /Testing/*
+.pio
+.vscode

--- a/src/ArduinoFake.h
+++ b/src/ArduinoFake.h
@@ -17,6 +17,7 @@
 #include "SerialFake.h"
 #include "ClientFake.h"
 #include "PrintFake.h"
+#include "SPIFake.h"
 
 #define ArduinoFake(mock) _ArduinoFakeGet##mock()
 
@@ -37,6 +38,7 @@
 #define _ArduinoFakeGetStream() _ArduinoFakeGetMock(Stream)
 #define _ArduinoFakeGetClient() _ArduinoFakeGetMock(Client)
 #define _ArduinoFakeGetPrint() _ArduinoFakeGetMock(Print)
+#define _ArduinoFakeGetSPIClass() _ArduinoFakeGetMock(SPIClass)
 #define _ArduinoFakeGet() _ArduinoFakeGetMock(Function)
 
 #define _ArduinoFakeInstanceGetter1(mock) \
@@ -67,6 +69,7 @@ struct ArduinoFakeMocks
     fakeit::Mock<StreamFake> Stream;
     fakeit::Mock<ClientFake> Client;
     fakeit::Mock<PrintFake> Print;
+    fakeit::Mock<SPIClassFake> SPIClass;
 };
 
 struct ArduinoFakeInstances
@@ -76,6 +79,7 @@ struct ArduinoFakeInstances
     StreamFake* Stream;
     ClientFake* Client;
     PrintFake* Print;
+    SPIClassFake* SPIClass;
 };
 
 class ArduinoFakeContext
@@ -90,11 +94,13 @@ class ArduinoFakeContext
         _ArduinoFakeInstanceGetter1(Serial)
         _ArduinoFakeInstanceGetter1(Client)
         _ArduinoFakeInstanceGetter1(Function)
+        _ArduinoFakeInstanceGetter1(SPIClass)
 
         _ArduinoFakeInstanceGetter2(Print, Print)
         _ArduinoFakeInstanceGetter2(Client, Client)
         _ArduinoFakeInstanceGetter2(Stream, Stream)
         _ArduinoFakeInstanceGetter2(Serial, Serial_)
+        _ArduinoFakeInstanceGetter2(SPIClass, SPIClass)
 
         ArduinoFakeContext()
         {
@@ -110,6 +116,7 @@ class ArduinoFakeContext
             this->Mocks->Serial.Reset();
             this->Mocks->Client.Reset();
             this->Mocks->Print.Reset();
+            this->Mocks->SPIClass.Reset();
 
             Mapping[&::Serial] = this->Serial();
         }

--- a/src/SPIFake.cpp
+++ b/src/SPIFake.cpp
@@ -1,0 +1,18 @@
+#include "ArduinoFake.h"
+#include "SPIFake.h"
+
+void SPIClass::begin () {
+    return ArduinoFakeInstance(SPIClass, this)->begin();
+};
+
+void SPIClass::beginTransaction (SPISettings settings) {
+    return ArduinoFakeInstance(SPIClass, this)->beginTransaction(settings);
+};
+
+uint8_t SPIClass::transfer (uint8_t data) {
+    return ArduinoFakeInstance(SPIClass, this)->transfer(data);
+};
+
+void SPIClass::endTransaction (void) {
+    return ArduinoFakeInstance(SPIClass, this)->endTransaction();
+};

--- a/src/SPIFake.h
+++ b/src/SPIFake.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "ArduinoFake.h"
+#include "FunctionFake.h"
+#include "arduino/SPI.h"
+
+struct SPIClassFake
+{
+    virtual void begin() = 0;
+    virtual void beginTransaction(SPISettings settings) = 0;
+    virtual uint8_t transfer(uint8_t data) = 0;
+    virtual void endTransaction(void) = 0;
+};
+
+class SPIClassFakeProxy : public SPIClass
+{
+    private:
+        SPIClassFake *spiClassFake;
+
+    public:
+        SPIClassFakeProxy(SPIClassFake *fake)
+        {
+            spiClassFake = fake;
+        }
+
+        SPIClassFake *getSPIClassFake()
+        {
+            return spiClassFake;
+        }
+};

--- a/src/arduino/SPI.h
+++ b/src/arduino/SPI.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010 by Cristian Maglie <c.maglie@arduino.cc>
+ * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
+ * Copyright (c) 2014 by Matthijs Kooijman <matthijs@stdin.nl> (SPISettings AVR)
+ * Copyright (c) 2014 by Andrew J. Kroll <xxxajk@gmail.com> (atomicity fixes)
+ * SPI Master library for arduino.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License version 2
+ * or the GNU Lesser General Public License version 2.1, both as
+ * published by the Free Software Foundation.
+ */
+
+#pragma once
+#include <stdlib.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+// SPI_HAS_TRANSACTION means SPI has beginTransaction(), endTransaction(),
+// usingInterrupt(), and SPISetting(clock, bitOrder, dataMode)
+#define SPI_HAS_TRANSACTION 1
+
+// SPI_HAS_NOTUSINGINTERRUPT means that SPI has notUsingInterrupt() method
+#define SPI_HAS_NOTUSINGINTERRUPT 1
+
+// SPI_ATOMIC_VERSION means that SPI has atomicity fixes and what version.
+// This way when there is a bug fix you can check this define to alert users
+// of your code if it uses better version of this library.
+// This also implies everything that SPI_HAS_TRANSACTION as documented above is
+// available too.
+#define SPI_ATOMIC_VERSION 1
+
+// Uncomment this line to add detection of mismatched begin/end transactions.
+// A mismatch occurs if other libraries fail to use SPI.endTransaction() for
+// each SPI.beginTransaction().  Connect an LED to this pin.  The LED will turn
+// on if any mismatch is ever detected.
+//#define SPI_TRANSACTION_MISMATCH_LED 5
+
+#ifndef LSBFIRST
+#define LSBFIRST 0
+#endif
+#ifndef MSBFIRST
+#define MSBFIRST 1
+#endif
+
+#define SPI_CLOCK_DIV4 0x00
+#define SPI_CLOCK_DIV16 0x01
+#define SPI_CLOCK_DIV64 0x02
+#define SPI_CLOCK_DIV128 0x03
+#define SPI_CLOCK_DIV2 0x04
+#define SPI_CLOCK_DIV8 0x05
+#define SPI_CLOCK_DIV32 0x06
+
+#define SPI_MODE0 0x00
+#define SPI_MODE1 0x04
+#define SPI_MODE2 0x08
+#define SPI_MODE3 0x0C
+
+#define SPI_MODE_MASK 0x0C  // CPOL = bit 3, CPHA = bit 2 on SPCR
+#define SPI_CLOCK_MASK 0x03  // SPR1 = bit 1, SPR0 = bit 0 on SPCR
+#define SPI_2XCLOCK_MASK 0x01  // SPI2X = bit 0 on SPSR
+
+// define SPI_AVR_EIMSK for AVR boards with external interrupt pins
+#if defined(EIMSK)
+  #define SPI_AVR_EIMSK  EIMSK
+#elif defined(GICR)
+  #define SPI_AVR_EIMSK  GICR
+#elif defined(GIMSK)
+  #define SPI_AVR_EIMSK  GIMSK
+#endif
+
+class SPISettings {
+public:
+  SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) {
+  }
+  SPISettings() {
+    SPISettings(4000000, MSBFIRST, SPI_MODE0);
+  }
+  friend class SPIClass;
+};
+
+
+class SPIClass {
+public:
+  // Initialize the SPI library
+  static void begin();
+
+  // Before using SPI.transfer() or asserting chip select pins,
+  // this function is used to gain exclusive access to the SPI bus
+  // and configure the correct settings.
+  static void beginTransaction(SPISettings settings);
+
+  // Write to the SPI bus (MOSI pin) and also receive (MISO pin)
+  static uint8_t transfer(uint8_t data);
+
+  // After performing a group of transfers and releasing the chip select
+  // signal, this function allows others to access the SPI bus
+  static void endTransaction(void);
+
+private:
+};


### PR DESCRIPTION
Hi I am trying to add [SPI Arduino Core library ](https://github.com/arduino/ArduinoCore-avr/tree/master/libraries/SPI) and contribute in ArduinoFake for the community. 
I have followed the contribution guidelines and added SPI the same way as the `Print` since its quite similar to it. The issue was that I encountered an error that I was stuck on `ArduinoFake.h`:
```In file included from src/Arduino.h:1,
                 from test/main.cpp:1:
src/ArduinoFake.h: In member function ‘SPIClassFake* ArduinoFakeContext::SPIClass(SPIClass*)’:
src/ArduinoFake.h:59:52: error: cannot dynamic_cast ‘instance’ (of type ‘class SPIClass*’) to type ‘class SPIClassFakeProxy*’ (source type is not polymorphic)
         if (dynamic_cast<name##FakeProxy*>(instance)) { \
                                                    ^
src/ArduinoFake.h:103:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
         _ArduinoFakeInstanceGetter2(SPIClass, SPIClass)
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ArduinoFake.h:60:59: error: cannot dynamic_cast ‘instance’ (of type ‘class SPIClass*’) to type ‘class SPIClassFakeProxy*’ (source type is not polymorphic)
             return dynamic_cast<name##FakeProxy*>(instance)->get##name##Fake(); \
                                                           ^
src/ArduinoFake.h:103:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
         _ArduinoFakeInstanceGetter2(SPIClass, SPIClass)` 
```
It showed when I added `_ArduinoFakeInstanceGetter2(SPIClass, SPIClass)` on `ArduinoFakeContext`.
